### PR TITLE
Handle eth_pairings only

### DIFF
--- a/src/Nethermind.Crypto.Pairings/Pairings.cs
+++ b/src/Nethermind.Crypto.Pairings/Pairings.cs
@@ -100,10 +100,10 @@ public static class Pairings
             return IntPtr.Zero;
         }
 
-        (string? platform, string? extension) =
-            RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? ("linux", "so") :
-            RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ("osx", "dylib") :
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ("win", "dll") : default;
+        (string? platform, string? name) =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? ("linux", "libeth_pairings.so") :
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ("osx", "libeth_pairings.dylib") :
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ("win", "eth_pairings.dll") : default;
 
         if (platform is null)
         {
@@ -122,6 +122,6 @@ public static class Pairings
             return IntPtr.Zero;
         }
 
-        return NativeLibrary.Load(Path.Combine(AppContext.BaseDirectory, $"runtimes/{platform}-{arch}/native/{path}.{extension}"));
+        return NativeLibrary.Load(Path.Combine(AppContext.BaseDirectory, $"runtimes/{platform}-{arch}/native/{name}"));
     }
 }


### PR DESCRIPTION
If eth_pairings native binaries are not present it will fall into recursion. The same happens for any other not found library:
`OnResolvingUnmanagedDll` is called and has no filter, so it tries to load with `NativeLibrary.Load`, which fails to find binaries in updated path and calls `OnResolvingUnmanagedDll` again, untill stack overflows